### PR TITLE
Fix Vic bank selection

### DIFF
--- a/src/c64.rs
+++ b/src/c64.rs
@@ -144,7 +144,6 @@ bitflags! {
     /// ~~~
     /// set_vic_bank(cia::VicBankSelect::RegionC000);
     /// ~~~
-    #[derive(Clone, Copy)]
     pub struct VicBankSelect: u8 {
         /// Bank 3: 0xC000-0xFFFF
         const RegionC000 = 0;
@@ -267,6 +266,6 @@ pub fn set_vic_bank(bank: VicBankSelect) {
         cia2().data_direction_port_a.write(dir_a | 0b11);
         cia2()
             .port_a
-            .write(port_a & VicBankSelect::VIC_0000.complement() | bank);
+            .write(port_a & VicBankSelect::Region0000.complement() | bank);
     }
 }

--- a/src/cia.rs
+++ b/src/cia.rs
@@ -62,7 +62,7 @@ pub struct MOSComplexInterfaceAdapter6526<T1: Copy, T2: Copy> {
     pub control_b: RW<u8>,             // 0x0f
 }
 
-const_assert!(size_of::<MOSComplexInterfaceAdapter6526>() == 16);
+const_assert!(size_of::<MOSComplexInterfaceAdapter6526<GameController, GameController>>() == 16);
 
 /// Enum for joystick positions
 pub enum JoystickPosition {
@@ -188,7 +188,6 @@ bitflags! {
     /// serial bus input (0=Low/Active, 1=High/Inactive)
     /// - CLOCK IN
     /// - DATA IN
-    #[derive(Clone, Copy)]
     pub struct SerialBusAccess: u8 {
         const TXD_OUT  = 0b0000_0100;
         const ATN_OUT  = 0b0000_1000;
@@ -210,7 +209,6 @@ bitflags! {
     /// - 5 User Port Pin J IO
     /// - 6 CTS R
     /// - 7 DSR R
-    #[derive(Clone, Copy)]
     pub struct RS232Access: u8 {
         const RXD  = 0b0000_0001;
         const RTS  = 0b0000_0010;


### PR DESCRIPTION
Looks like #43 broke some things. VicBankSelect region is wrong and there's unnecessary derives that `bitflags!` adds by default.